### PR TITLE
Fix #11084 Add 'chronos' to unix_users.txt

### DIFF
--- a/data/wordlists/unix_users.txt
+++ b/data/wordlists/unix_users.txt
@@ -16,6 +16,7 @@ bin
 checkfs
 checkfsys
 checksys
+chronos
 cmwlogin
 couchdb
 daemon


### PR DESCRIPTION
This commit adds the username 'chronos' to the user list as it happens to be the default username on ChromeOS, as highlighted by @h00die in Issue #11084


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

